### PR TITLE
Refactor upload

### DIFF
--- a/extra_scripts/qemu_upload.py
+++ b/extra_scripts/qemu_upload.py
@@ -91,7 +91,7 @@ def start_qemu_emulator(source, target, env):
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", build_emulator_image)  # type: ignore
 
 # DO NOT interfere with Unity tests conducted by pio
-if env["BUILD_TYPE"] != "debug, test":  # type: ignore
+if "test" in env["BUILD_TYPE"]:  # type: ignore
     # Replace the upload command with our custom function
     env.Depends(  # type: ignore
         "upload",

--- a/extra_scripts/qemu_upload.py
+++ b/extra_scripts/qemu_upload.py
@@ -46,7 +46,7 @@ def build_emulator_image(source, target, env):
     ]
 
     print(f"Building image with command:\n {' '.join(command)}")
-    result = subprocess.run(command, capture_output=True)
+    result = subprocess.run(command, capture_output=True, check=True)
     if result.returncode != 0:
         print(result.stdout)
         return False
@@ -71,12 +71,12 @@ def start_qemu_emulator(source, target, env):
     if env.GetProjectOption("build_type") == 'debug':
         qemu_cmd = qemu_cmd + [ '-s', '-S' ]
 
-    print(f"Starting ESP32 QEMU emulator...")
+    print("Starting ESP32 QEMU emulator...")
     print(f"Emulator Command: {' '.join(qemu_cmd)}")
-    
+
     try:
         # Start QEMU (this will block until QEMU exits)
-        result = subprocess.run(qemu_cmd, check=True)
+        _ = subprocess.run(qemu_cmd, check=True)
         print("QEMU emulator started successfully")
         return 0
     except subprocess.CalledProcessError as e:

--- a/extra_scripts/qemu_upload.py
+++ b/extra_scripts/qemu_upload.py
@@ -70,7 +70,7 @@ def start_qemu_emulator(source, target, env):
 
     # print(env.Dump())
     if env.GetProjectOption("build_type") == "debug":
-        qemu_cmd = qemu_cmd + ["-s", "-S"]
+        qemu_cmd += ["-s", "-S"]
 
     print("Starting ESP32 QEMU emulator...")
     print(f"Emulator Command: {' '.join(qemu_cmd)}")

--- a/extra_scripts/qemu_upload.py
+++ b/extra_scripts/qemu_upload.py
@@ -1,20 +1,20 @@
-#**********************************************************************************
+# *****************************************************************************
 # Copyright (C) 2025 Craig Setera
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-#*********************************************************************************/
+# *****************************************************************************
 import os
 import subprocess
 
-Import("env") # type: ignore
+Import("env")  # type: ignore
 
-platform = env.PioPlatform() # type: ignore
-board_config = env.BoardConfig() # type: ignore
+platform = env.PioPlatform()  # type: ignore
+board_config = env.BoardConfig()  # type: ignore
 build_mcu = board_config.get("build.mcu")
 # Get the compiled firmware path
-flash_image = env.File("$BUILD_DIR/flash_image.bin").abspath # type: ignore
+flash_image = env.File("$BUILD_DIR/flash_image.bin").abspath  # type: ignore
 
 
 def build_emulator_image(source, target, env):
@@ -32,17 +32,17 @@ def build_emulator_image(source, target, env):
             bootloader_offset = "0x0000"
 
     command = [
-        os.path.join(esptool_dir, 'esptool.py'),
-        '--chip', build_mcu,
-        'merge_bin',
-        '-o', flash_image,
-        '--fill-flash-size', board_config.get("upload.flash_size"),
-        '--flash_size', 'keep',
-        '--flash_mode', env['BOARD_FLASH_MODE'], # type: ignore
-        '--flash_freq', '40m',
-        bootloader_offset, env.File('$BUILD_DIR/bootloader.bin').abspath, # type: ignore
-        '0x8000', env.File('$BUILD_DIR/partitions.bin').abspath, # type: ignore
-        '0x10000', env.File('$BUILD_DIR/firmware.bin').abspath, # type: ignore
+        os.path.join(esptool_dir, "esptool.py"),
+        "--chip", build_mcu,
+        "merge_bin",
+        "-o", flash_image,
+        "--fill-flash-size", board_config.get("upload.flash_size"),
+        "--flash_size", "keep",
+        "--flash_mode", env["BOARD_FLASH_MODE"],  # type: ignore
+        "--flash_freq", "40m",
+        bootloader_offset, env.File("$BUILD_DIR/bootloader.bin").abspath,  # type: ignore
+        "0x8000", env.File("$BUILD_DIR/partitions.bin").abspath,  # type: ignore
+        "0x10000", env.File("$BUILD_DIR/firmware.bin").abspath,  # type: ignore
     ]
 
     print(f"Building image with command:\n {' '.join(command)}")
@@ -60,17 +60,17 @@ def start_qemu_emulator(source, target, env):
 
     # QEMU command and arguments
     qemu_cmd = [
-        'qemu-system-xtensa',
-        '-machine', build_mcu,
+        "qemu-system-xtensa",
+        "-machine", build_mcu,
         "-drive", f"file={flash_image},if=mtd,format=raw",
-        '-display', 'gtk',
-        '-serial', 'stdio',
-        '-d', 'guest_errors',
+        "-display", "gtk",
+        "-serial", "stdio",
+        "-d", "guest_errors",
     ]
-    
+
     # print(env.Dump())
-    if env.GetProjectOption("build_type") == 'debug':
-        qemu_cmd = qemu_cmd + [ '-s', '-S' ]
+    if env.GetProjectOption("build_type") == "debug":
+        qemu_cmd = qemu_cmd + ["-s", "-S"]
 
     print("Starting ESP32 QEMU emulator...")
     print(f"Emulator Command: {' '.join(qemu_cmd)}")
@@ -88,12 +88,12 @@ def start_qemu_emulator(source, target, env):
         return 1
 
 
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", build_emulator_image) # type: ignore
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", build_emulator_image)  # type: ignore
 
 # DO NOT interfere with Unity tests conducted by pio
-if env["BUILD_TYPE"] != "debug, test": # type: ignore
+if env["BUILD_TYPE"] != "debug, test":  # type: ignore
     # Replace the upload command with our custom function
-    env.Depends( # type: ignore
+    env.Depends(  # type: ignore
         "upload",
         [
             "$BUILD_DIR/bootloader.bin",
@@ -101,4 +101,4 @@ if env["BUILD_TYPE"] != "debug, test": # type: ignore
             "$BUILD_DIR/${PROGNAME}.bin",
         ],
     )
-    env.Replace(UPLOADCMD=start_qemu_emulator) # type: ignore
+    env.Replace(UPLOADCMD=start_qemu_emulator)  # type: ignore

--- a/extra_scripts/qemu_upload.py
+++ b/extra_scripts/qemu_upload.py
@@ -5,9 +5,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 #*********************************************************************************/
-Import("env") # type: ignore
 import os
 import subprocess
+
+Import("env") # type: ignore
 
 platform = env.PioPlatform() # type: ignore
 board_config = env.BoardConfig() # type: ignore

--- a/extra_scripts/qemu_upload.py
+++ b/extra_scripts/qemu_upload.py
@@ -48,11 +48,12 @@ def build_emulator_image(source, target, env):
     print(f"Building image with command:\n {' '.join(command)}")
     result = subprocess.run(command, capture_output=True, check=True)
     if result.returncode != 0:
+        print("ERROR:")
         print(result.stdout)
-        return False
-    else:
-        print("Image built")
-        return True
+        return 1
+    print("Image built")
+    return 0
+
 
 def start_qemu_emulator(source, target, env):
     """Custom upload function that starts ESP32 QEMU instead of flashing"""

--- a/extra_scripts/qemu_upload.py
+++ b/extra_scripts/qemu_upload.py
@@ -64,7 +64,7 @@ def start_qemu_emulator(source, target, env):
         "-machine", build_mcu,
         "-drive", f"file={flash_image},if=mtd,format=raw",
         "-display", "gtk",
-        "-serial", "stdio",
+        "-serial", "mon:stdio",
         "-d", "guest_errors",
     ]
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ ninja -C build
 
 ## Building for Emulator
 
-In this example project, the upload target has been overriden via [qemu_upload.py](extra-scripts/qemu_upload.py) to build a flash image and launch the emulator.
+In this example project, the upload target has been overriden via [qemu_upload.py](extra_scripts/qemu_upload.py) to build a flash image and launch the emulator.
 
 More info:
 * https://github.com/espressif/esp-toolchain-docs/blob/main/gcc/build-and-run-native-app.md


### PR DESCRIPTION
Hi,

I suggest a few changes to your code, which I found very useful:

- Python fixes, typos + PEP8
- Separation of the image creation process and the QEMU launch process.
The `pio test` command itself launches unit tests in QEMU, and the script's target upload overload is not compatible.
- The `-serial stdio` option does not work for me and generates this error:
```
qemu-system-xtensa: -serial stdio: cannot use stdio by multiple character devices
qemu-system-xtensa: -serial stdio: could not connect serial device to character backend “stdio”
```
This is fixed by adding the prefix `mon:stdio`.

Also, under ESP32S3, I get this error:
`eFuse: calibration efuse version does not match, set default version to 0`
Discussed here: https://github.com/espressif/esp-insights/issues/38#issuecomment-1976104736

This is resolved by adding these lines to the qemu command (after burning the fuses with espefuse):
```
-drive file=qemu_efuse.bin,if=none,format=raw,id=efuse
-global driver=nvram.esp32s3.efuse,property=drive,value=efuse
```
I did not add this change, but I think it would be good to add it to your readme.