### PR TITLE
[script] Add support for PSRAM

### DIFF
--- a/extra_scripts/qemu_upload.py
+++ b/extra_scripts/qemu_upload.py
@@ -67,7 +67,10 @@ def start_qemu_emulator(source, target, env):
         '-serial', 'stdio',
         '-d', 'guest_errors',
     ]
-    
+
+    if "-DBOARD_HAS_PSRAM" in board_config.get("build.extra_flags"):
+        qemu_cmd += ["-m", "16M"]
+
     # print(env.Dump())
     if env.GetProjectOption("build_type") == 'debug':
         qemu_cmd = qemu_cmd + [ '-s', '-S' ]

--- a/extra_scripts/qemu_upload.py
+++ b/extra_scripts/qemu_upload.py
@@ -71,6 +71,10 @@ def start_qemu_emulator(source, target, env):
     if "-DBOARD_HAS_PSRAM" in board_config.get("build.extra_flags"):
         qemu_cmd += ["-m", "16M"]
 
+    # Octal PSRAM detected
+    if "opi" == board_config.get("build.psram_type"):
+        qemu_cmd += ["-global", "driver=ssi_psram,property=is_octal,value=true"]
+
     # print(env.Dump())
     if env.GetProjectOption("build_type") == 'debug':
         qemu_cmd = qemu_cmd + [ '-s', '-S' ]


### PR DESCRIPTION
Hi,

QEMU should support PSRAM with options like `-m 8M`. On my side I have errors if I enable it via menuconfig, but a recent commit has been published:
https://github.com/espressif/qemu/commit/30f83141bb392ddffa3cb8260ebfd4e5afe3af9b

It is not tested on my side (I'm using the precompiled release of QEMU 9.2.2-20250228) but the modification should be the way to implement it.